### PR TITLE
(maint) Move gem based configuration to dev file

### DIFF
--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -10,3 +10,7 @@ analytics:
   provider               : false  # false (default), "google", "google-universal", "custom"
   google:
     tracking_id          :
+
+# Minimal Mistakes Theme information
+# The gem theme is only need when in Dev mode, otherwise github complains.
+theme: minimal-mistakes-jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ atom_feed:
   path                   : # blank (default) uses feed.xml
 
 # Minimal Mistakes Theme information
-theme: minimal-mistakes-jekyll
+# The `theme` property must not be set here otherwise github pages complains
 # Remember to update the _config.yml with the same version
 remote_theme: mmistakes/minimal-mistakes@4.11.1
 minimal_mistakes_skin: "default"


### PR DESCRIPTION
Github pages complains if using an unknown theme name.  This commit moves the
theme name definition to the DEV environment as it's needed when using the gem
based theme, but not under GH pages.